### PR TITLE
Add pm1 and pm10 fields to key map

### DIFF
--- a/blueair/blueair.py
+++ b/blueair/blueair.py
@@ -24,6 +24,8 @@ def transform_data_points(data: MeasurementBundle) -> MeasurementList:
     key_mapping = {
         "time": "timestamp",
         "pm": "pm25",
+        "pm1": "pm1",
+        "pm10": "pm10",
         "tmp": "temperature",
         "hum": "humidity",
         "co2": "co2",


### PR DESCRIPTION
My BlueAir unit returns additional PM fields that arn't mapped in the transform and throw a key error when being processed. Units that don't have the additional fields should not be impacted by their inclusion in the transform map.

Blue Air: 
`'compatibility':` 'classic_280i', 'timezone': 'America/Los_Angeles', 'model': '1.0.9', 'firmware': '1.1.38'

Example API Response:
```
{'uuid': 'XXXXXXXXXXXXXXXX',
 'start': 1613787478,
 'end': 1613787478,
 'sensors': ['time',
  'pm',
  'pm1',
  'pm10',
  'voc',
  'co2',
  'tmp',
  'hum',
  'allpollu'],
 'units': ['s', 'ugm3', 'ugm3', 'ugm3', 'ppb', 'ppm', 'C', 'pc', '%'],
 'datapoints': [[1613787478,
   0.0,
   0.0,
   0.0,
   296,
   772,
   19.656,
   55.324,
   24.428572]]}
```